### PR TITLE
Fix compile error in setup-helm.el

### DIFF
--- a/custom/setup-helm.el
+++ b/custom/setup-helm.el
@@ -3,6 +3,11 @@
   (progn
     (require 'helm-config)
     (require 'helm-grep)
+    ;; To fix error at compile:
+    ;; Error (bytecomp): Forgot to expand macro with-helm-buffer in
+    ;; (with-helm-buffer helm-echo-input-in-header-line)
+    (if (version< "26.0.50" emacs-version)
+        (eval-when-compile (require 'helm-lib)))
 
     (defun helm-hide-minibuffer-maybe ()
       (when (with-helm-buffer helm-echo-input-in-header-line)


### PR DESCRIPTION
I compile my setup-* but emacs version 26.0.50 produce error:

 Error (bytecomp): Forgot to expand macro with-helm-buffer in (with-helm-buffer helm-echo-input-in-header-line)

This is simple fix.

P.S. Thank you for your tutorial :)
