### PR TITLE
Use use-package for comment-dwim-2 

### DIFF
--- a/custom/setup-editing.el
+++ b/custom/setup-editing.el
@@ -77,7 +77,9 @@
   (add-hook 'fundamental-mode 'ws-butler-mode))
 
 ;; PACKAGE: comment-dwim-2
-(global-set-key (kbd "M-;") 'comment-dwim-2)
+(use-package comment-dwim-2
+  :bind (("M-;" . comment-dwim-2))
+  )
 
 ;; PACKAGE: anzu
 ;; GROUP: Editing -> Matching -> Isearch -> Anzu

--- a/custom/setup-ivy-counsel.el
+++ b/custom/setup-ivy-counsel.el
@@ -20,6 +20,6 @@
 
 (use-package counsel-projectile
   :init
-  (counsel-projectile-on))
+  (counsel-projectile-mode))
 
 (provide 'setup-ivy-counsel)


### PR DESCRIPTION
Use use-package for comment-dwim-2 instead of setting global kbd command. The latter fails if comment-dwim-2 is not installed on user's computer.